### PR TITLE
Add ability to initialize subclasses with a block

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,8 @@ jobs:
         ruby-version: '${{ matrix.ruby }}'
         bundler-cache: true
 
-    - name: Run tests
+    - name: Run specs
       run: bundle exec rspec
+
+    - name: Run README docspec
+      run: bundle exec docspec

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :development do
 end
 
 group :test do
+  gem 'docspec'
   gem 'rspec'
   gem 'rspec_approvals'
   gem 'simplecov'

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ p skin.color
 #=> :blue
 
 # Note that when initializing a subclass with a hash, it will replace
-# the given branch. In this case border.width will be erased.
+# the given branch. In this case border.width will be lost.
 skin = Skin.new border: { color: :yellow }
 puts skin.border  
 #=> color = :yellow
@@ -93,9 +93,6 @@ skin = Skin.new { border.color = :yellow }
 puts skin.border
 #=> color = :yellow
 #=> width = 3
-
-
-
 ```
 
 ## Contributing / Support

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ $ gem install dot_options
 ## Usage
 
 ```ruby
+# Usage
 require 'dot_options'
 
 # Initialize a DotOptions object with a hash:
@@ -58,6 +59,7 @@ p options
 Subclassing `DotOptions` is a useful way to have an object with default options.
 
 ```ruby
+# Subclassing
 require 'dot_options'
 
 class Skin < DotOptions

--- a/README.md
+++ b/README.md
@@ -28,29 +28,29 @@ opts = {
 options = DotOptions.new opts
 
 # Read any option with dot-notation:
-p options.skin.background.color  # => :black
+p options.skin.background.color
+#=> :black
 
 # Update any option with dot-notation:
 options.skin.background.color = :black
 
 # ... or create an entire branch by providing a hash
 options.skin.foreground = { color: :white, font: 'JetBrains Mono' }
-p options.skin.foreground.font  # => 'JetBrains Mono'
+p options.skin.foreground.font
+#=> "JetBrains Mono"
 
 # Print a flat view of all options
 puts options
-# => debug = true
-# => output.color = true
-# => skin.background.color = :black
-# => skin.background.texture = "Stripes"
-# => skin.foreground.color = :white
-# => skin.foreground.font = "JetBrains Mono"
+#=> debug = true
+#=> output.color = true
+#=> skin.background.color = :black
+#=> skin.background.texture = "Stripes"
+#=> skin.foreground.color = :white
+#=> skin.foreground.font = "JetBrains Mono"
 
 # ... or a compact inspection string
 p options
-# => { debug: true, output: { color: true },
-# =>   skin: { background: { color: :black, texture: "Stripes" },
-# =>   foreground: { color: :white, font: "JetBrains Mono" } } }
+#=> { debug: true, output: { color: true }, skin: { background: { color: :black, texture: "Stripes" }, foreground: { color: :white, font: "JetBrains Mono" } } }
 ```
 
 ### Subclassing
@@ -74,11 +74,28 @@ end
 
 # Get an object with the default settings
 skin = Skin.new 
-p skin.background.color  # => :lime
+p skin.background.color
+#=> :lime
 
 # Get an object and override some settings
 skin = Skin.new color: :blue
-p skin.color  # => :blue
+p skin.color
+#=> :blue
+
+# Note that when initializing a subclass with a hash, it will replace
+# the given branch. In this case border.width will be erased.
+skin = Skin.new border: { color: :yellow }
+puts skin.border  
+#=> color = :yellow
+
+# You can overcome this by initializing with a block
+skin = Skin.new { border.color = :yellow }
+puts skin.border
+#=> color = :yellow
+#=> width = 3
+
+
+
 ```
 
 ## Contributing / Support

--- a/lib/dot_options.rb
+++ b/lib/dot_options.rb
@@ -4,11 +4,12 @@ class DotOptions
   attr_reader :options
   attr_accessor :key, :parent
 
-  def initialize(options = {})
+  def initialize(options = {}, &block)
     @options = options
     @key = nil
     @parent = nil
     build_options
+    instance_eval(&block) if block_given?
   end
 
   def inspect

--- a/lib/dot_options.rb
+++ b/lib/dot_options.rb
@@ -9,7 +9,7 @@ class DotOptions
     @key = nil
     @parent = nil
     build_options
-    instance_eval(&block) if block_given?
+    instance_eval(&block) if block_given?  # for subclasses
   end
 
   def inspect

--- a/lib/dot_options.rb
+++ b/lib/dot_options.rb
@@ -9,7 +9,7 @@ class DotOptions
     @key = nil
     @parent = nil
     build_options
-    instance_eval(&block) if block_given?  # for subclasses
+    instance_eval(&block) if block
   end
 
   def inspect

--- a/spec/dot_options/subclassing_spec.rb
+++ b/spec/dot_options/subclassing_spec.rb
@@ -34,4 +34,16 @@ describe 'DotOptions subclassing' do
       expect(subject.code.font).to eq 'JetBrains Mono'
     end
   end
+
+  context 'when initializing with a block' do
+    subject { Skin.new { border.color = :dark_red }  }
+    
+    it 'evaluates the block with the instance context' do
+      expect(subject.border.color).to eq :dark_red
+    end
+
+    it 'retains the original options structure' do
+      expect(subject.border.width).to eq 3
+    end
+  end
 end

--- a/spec/dot_options/subclassing_spec.rb
+++ b/spec/dot_options/subclassing_spec.rb
@@ -36,8 +36,8 @@ describe 'DotOptions subclassing' do
   end
 
   context 'when initializing with a block' do
-    subject { Skin.new { border.color = :dark_red }  }
-    
+    subject { Skin.new { border.color = :dark_red } }
+
     it 'evaluates the block with the instance context' do
       expect(subject.border.color).to eq :dark_red
     end


### PR DESCRIPTION
Add the ability to initialize with a block when subclassing:

```ruby
class Skin < DotOptions
  DEFAULTS = {
    color: :black,
    border: { color: :red, width: 3 },
    background: { color: :lime, texture: 'Stripes' },
  }

  def initialize(options = nil)
    super DEFAULTS.merge(options || {})
  end
end

skin = Skin.new { border.color = :yellow }
```

In addition, this PR adds docspec tests on the README.