### PR TITLE
Refactor to set attr_accessors instead of using method_missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,8 @@ options = DotOptions.new opts
 p options.skin.background.color
 #=> :black
 
-# Update any option with dot-notation:
+# Update any option leaf with dot-notation:
 options.skin.background.color = :black
-
-# ... or create an entire branch by providing a hash
-options.skin.foreground = { color: :white, font: 'JetBrains Mono' }
-p options.skin.foreground.font
-#=> "JetBrains Mono"
 
 # Print a flat view of all options
 puts options
@@ -46,12 +41,10 @@ puts options
 #=> output.color = true
 #=> skin.background.color = :black
 #=> skin.background.texture = "Stripes"
-#=> skin.foreground.color = :white
-#=> skin.foreground.font = "JetBrains Mono"
 
 # ... or a compact inspection string for any branch
-p options.skin.background
-#=> { color: :black, texture: "Stripes" }
+p options.skin
+#=> <background: <color: :black, texture: "Stripes">>
 ```
 
 ### Subclassing
@@ -76,32 +69,32 @@ class Skin < DotOptions
   end
 end
 
-# Get an object with the default settings
+# Get an object with the default options
 skin = Skin.new 
 p skin.background.color
 #=> :lime
 
-# Get an object and override some settings
+# Get an object and override some root options using a hash
 skin = Skin.new color: :blue
 p skin.color
 #=> :blue
 
-# Note that when initializing a subclass with a hash, it will replace
-# the given branch. In this case border.width will be lost.
-skin = Skin.new border: { color: :yellow }
-puts skin.border  
-#=> color = :yellow
-
-# You can overcome this by initializing with a block, like this:
+# Get an object and update some deep options using a block
 skin = Skin.new { border.color = :yellow }
 puts skin.border
 #=> color = :yellow
 #=> width = 3
 
-# ... or like this
-skin = Skin.new { |skin| skin.color = :cyan }
+# The initialization block receives the object itself which can be useful
+# in some cases
+skin = Skin.new do |skin|
+  skin.color = :cyan
+  skin.border.width = 10
+end
 p skin.color
+p skin.border
 #=> :cyan
+#=> <color: :red, width: 10>
 ```
 
 ## Contributing / Support

--- a/lib/dot_options.rb
+++ b/lib/dot_options.rb
@@ -44,7 +44,7 @@ private
         value._parent = self
       end
 
-      send "#{key}=", value
+      send :"#{key}=", value
     end
   end
 

--- a/spec/approvals/inspect
+++ b/spec/approvals/inspect
@@ -1,1 +1,1 @@
-{ debug: true, output: { color: true }, skin: { background: { color: :black, texture: "Stripes" } } }
+<debug: true, output: <color: true>, skin: <background: <color: :black, texture: "Stripes">>>

--- a/spec/dot_options/dot_options_spec.rb
+++ b/spec/dot_options/dot_options_spec.rb
@@ -31,7 +31,7 @@ describe DotOptions do
     end
   end
 
-  describe '#method_missing' do
+  describe 'dynamic attributes' do
     it 'enables read access to deeply nested options' do
       expect(subject.skin.background.color).to eq :black
     end
@@ -39,19 +39,6 @@ describe DotOptions do
     it 'enables write access to deeply nested options' do
       subject.skin.background.color = :blue
       expect(subject.skin.background.color).to eq :blue
-    end
-
-    context 'when assigning a hash' do
-      it 'converts it to a DotOptions' do
-        subject.skin.foreground = { color: :white, font: 'JetBrains Mono' }
-        expect(subject.skin.foreground.color).to eq :white
-      end
-    end
-
-    context 'with an invalid option' do
-      it 'raises OptionNotFoundError with a clear message' do
-        expect { subject.skin.background.border }.to raise_approval('option-not-found')
-      end
     end
 
     context 'when the object was initialized with string keys' do


### PR DESCRIPTION
Switch from using `method_missing` to deliver properties, to setting `attr_accessor` on initialization. This implementation is cleaner, but comes at a cost:

1. There will no longer be a friendly "Option not found 'some.option.key'" error. It will instead be a normal `NoMethodError`
2. The after-the-fact creation of new branches is no longer supported. 